### PR TITLE
Bug correction: locks didn't clear on Reset()

### DIFF
--- a/Gear/EmulationCore/Propeller.cs
+++ b/Gear/EmulationCore/Propeller.cs
@@ -509,6 +509,7 @@ namespace Gear.EmulationCore
                 ClockSources[i] = null;
                 Cogs[i] = null;
                 LocksAvailable[i] = true;
+                LocksState[i] = false;
             }
 
             foreach (PluginBase mod in PlugIns)
@@ -538,7 +539,7 @@ namespace Gear.EmulationCore
 
         public void Stop(int cog)
         {
-            if (cog >= 8 || cog < 0)
+            if (cog >= TOTAL_COGS || cog < 0)
                 return;
 
             if (Cogs[cog] != null)
@@ -778,7 +779,7 @@ namespace Gear.EmulationCore
                         uint progm = (arguement >> 2) & 0xFFFC;
 
                         // Start a new cog?
-                        if ((arguement & 0x08) != 0)
+                        if ((arguement & TOTAL_COGS) != 0)
                         {
                             for (uint i = 0; i < Cogs.Length; i++)
                             {

--- a/Gear/GUI/Emulator.Designer.cs
+++ b/Gear/GUI/Emulator.Designer.cs
@@ -247,7 +247,7 @@ namespace Gear.GUI
             this.closeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.closeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.closeButton.Name = "closeButton";
-            this.closeButton.Size = new System.Drawing.Size(40, 19);
+            this.closeButton.Size = new System.Drawing.Size(40, 22);
             this.closeButton.Text = "Close";
             this.closeButton.ToolTipText = "Close the tab window (if permitted)";
             this.closeButton.Click += new System.EventHandler(this.closeActiveTab_Click);

--- a/Gear/GUI/Emulator.cs
+++ b/Gear/GUI/Emulator.cs
@@ -50,8 +50,8 @@ namespace Gear.GUI
         private Timer runTimer;             //!< @todo Document Gear.GUI.Emulator.runtimer member (what it is for???)
 
         /// @brief Default Constructor.
-        /// @param[in] source Binary program loaded (path & name)
         /// 
+        /// @param[in] source Binary program loaded (path & name)
         public Emulator(string source)
         {
             Chip = new Propeller(this);

--- a/Gear/GUI/HubView.cs
+++ b/Gear/GUI/HubView.cs
@@ -50,7 +50,7 @@ namespace Gear.GUI
             }
         }
 
-        /// @brief update screen data on event
+        /// @brief Update screen data on event.
         /// 
         public void DataChanged()
         {


### PR DESCRIPTION
Running "Eight Talking Cogs" OBEX example, I  realize about a bug in GEAR: locks didn't clear on Reset().
As you were touching things in Propeller.cs, I think it is better to examine the changes...
