### PR TITLE
Fixed Z-flag behavior of instructions SUMC and SUMNC

### DIFF
--- a/Gear/EmulationCore/NativeCog.cs
+++ b/Gear/EmulationCore/NativeCog.cs
@@ -1125,7 +1125,7 @@ namespace Gear.EmulationCore
                 result += (int)SourceValue;
 
             DataResult = (uint)result;
-            ZeroResult = Zero && (DataResult == 0);
+            ZeroResult = (DataResult == 0);
             CarryResult = ((SourceValue ^ DestinationValue) & 0x80000000) == 0
                 && ((SourceValue ^ DataResult) & 0x80000000) != 0;
         }
@@ -1140,7 +1140,7 @@ namespace Gear.EmulationCore
                 result += (int)SourceValue;
 
             DataResult = (uint)result;
-            ZeroResult = Zero && (DataResult == 0);
+            ZeroResult = (DataResult == 0);
             CarryResult = ((SourceValue ^ DestinationValue) & 0x80000000) == 0
                 && ((SourceValue ^ DataResult) & 0x80000000) != 0;
         }


### PR DESCRIPTION
Hi there and thanks to all authors for their great work.

I guess I found a little bug regarding the Z-Flags of SUMC and SUMNC. According to the Parallax Propeller Manual (v1.2 page 356), the Z-Flag only depends on the current result:
``` zflag = (result == 0) ```

According to the Manual, this also applies to the following instructions (I did not test them):
``` SUMNZ, SUMZ, SUBX, ADDS ```

Here is a little PASM snippet to check the behavior (by commenting out the second CMP to toggle the previous Z-Flag state).

Best wishes!
```
         cmp      a, b  WC   ' Sets C so that SUMC is a subtraction
         cmp      a, a  WZ   ' Sets Z to check if it influences SUMC's Z-Flag behavior
         sumc     a, a  WZ   ' Sets the Z-Flag, results in a = 0

if_nz    wrlong   b, PAR
if_z     wrlong   a, PAR

         a        LONG  7
         b        LONG  13
         fit      496
```


