### PR TITLE
Correct video frame load timing, added video break, fix tab refresh

### DIFF
--- a/Gear/EmulationCore/PropellerCPU.cs
+++ b/Gear/EmulationCore/PropellerCPU.cs
@@ -717,11 +717,13 @@ namespace Gear.EmulationCore
 
             //execute a step on each cog
             for (int i = 0; i < Cogs.Length; i++)
+            {
                 if (Cogs[i] != null)
                 {
                     cogResult = Cogs[i].Step();
                     result &= cogResult;
                 }
+            }
 
             if ((RingPosition & 1) == 0)  // Every other clock, a cog gets a tick
             {

--- a/Gear/GUI/CogView.Designer.cs
+++ b/Gear/GUI/CogView.Designer.cs
@@ -68,6 +68,8 @@ namespace Gear.GUI
             this.carryFlagLabel = new System.Windows.Forms.ToolStripLabel();
             this.processorStateLabel = new System.Windows.Forms.ToolStripLabel();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.frameCountLabel = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripSeparator7 = new System.Windows.Forms.ToolStripSeparator();
             this.DisplayUnits = new System.Windows.Forms.ToolStripDropDownButton();
             this.decimalUnits = new System.Windows.Forms.ToolStripMenuItem();
             this.hexadecimalUnits = new System.Windows.Forms.ToolStripMenuItem();
@@ -76,49 +78,54 @@ namespace Gear.GUI
             this.longOpcodes = new System.Windows.Forms.ToolStripMenuItem();
             this.shortOpcodes = new System.Windows.Forms.ToolStripMenuItem();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.FrameBreakMode = new System.Windows.Forms.ToolStripDropDownButton();
+            this.toolStripSeparator8 = new System.Windows.Forms.ToolStripSeparator();
+            this.breakNone = new System.Windows.Forms.ToolStripMenuItem();
+            this.breakMiss = new System.Windows.Forms.ToolStripMenuItem();
+            this.breakAll = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStrip.SuspendLayout();
             this.SuspendLayout();
-            //
+            // 
             // toolStripSeparator4
-            //
+            // 
             toolStripSeparator4.Name = "toolStripSeparator4";
             toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
-            //
+            // 
             // toolStripSeparator1
-            //
+            // 
             toolStripSeparator1.Name = "toolStripSeparator1";
             toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
-            //
+            // 
             // toolStripSeparator2
-            //
+            // 
             toolStripSeparator2.Name = "toolStripSeparator2";
             toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
-            //
+            // 
             // toolStripSeparator3
-            //
+            // 
             toolStripSeparator3.Name = "toolStripSeparator3";
             toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
-            //
+            // 
             // assemblyPanel
-            //
+            // 
             this.assemblyPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.assemblyPanel.Location = new System.Drawing.Point(0, 25);
             this.assemblyPanel.Name = "assemblyPanel";
             this.assemblyPanel.Size = new System.Drawing.Size(548, 421);
             this.assemblyPanel.TabIndex = 1;
-            this.assemblyPanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.assemblyPanel_MouseDown);
-            this.assemblyPanel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.assemblyPanel_MouseMove);
-            this.assemblyPanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.assemblyPanel_MouseClick);
-            this.assemblyPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.AssemblyView_Paint);
-            this.assemblyPanel.MouseHover += new System.EventHandler(this.assemblyPanel_MouseHover);
             this.assemblyPanel.SizeChanged += new System.EventHandler(this.AsmSized);
-            //
+            this.assemblyPanel.Paint += new System.Windows.Forms.PaintEventHandler(this.AssemblyView_Paint);
+            this.assemblyPanel.MouseClick += new System.Windows.Forms.MouseEventHandler(this.assemblyPanel_MouseClick);
+            this.assemblyPanel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.assemblyPanel_MouseDown);
+            this.assemblyPanel.MouseHover += new System.EventHandler(this.assemblyPanel_MouseHover);
+            this.assemblyPanel.MouseMove += new System.Windows.Forms.MouseEventHandler(this.assemblyPanel_MouseMove);
+            // 
             // positionScroll
-            //
+            // 
             this.positionScroll.Dock = System.Windows.Forms.DockStyle.Right;
             this.positionScroll.LargeChange = 16;
             this.positionScroll.Location = new System.Drawing.Point(548, 25);
@@ -127,9 +134,9 @@ namespace Gear.GUI
             this.positionScroll.TabIndex = 2;
             this.positionScroll.TabStop = true;
             this.positionScroll.Scroll += new System.Windows.Forms.ScrollEventHandler(this.UpdateOnScroll);
-            //
+            // 
             // toolStrip
-            //
+            // 
             this.toolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.memoryViewButton,
             this.followPCButton,
@@ -142,28 +149,32 @@ namespace Gear.GUI
             toolStripSeparator3,
             this.processorStateLabel,
             this.toolStripSeparator5,
+            this.frameCountLabel,
+            this.toolStripSeparator7,
             this.DisplayUnits,
             this.toolStripSeparator6,
-            this.OpcodeSize});
+            this.OpcodeSize,
+            this.toolStripSeparator8,
+            this.FrameBreakMode});
             this.toolStrip.Location = new System.Drawing.Point(0, 0);
             this.toolStrip.Name = "toolStrip";
             this.toolStrip.Size = new System.Drawing.Size(565, 25);
             this.toolStrip.TabIndex = 0;
             this.toolStrip.Text = "toolStrip1";
-            //
+            // 
             // memoryViewButton
-            //
+            // 
             this.memoryViewButton.CheckOnClick = true;
             this.memoryViewButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.memoryViewButton.Image = ((System.Drawing.Image)(resources.GetObject("memoryViewButton.Image")));
             this.memoryViewButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.memoryViewButton.Name = "memoryViewButton";
-            this.memoryViewButton.Size = new System.Drawing.Size(78, 22);
+            this.memoryViewButton.Size = new System.Drawing.Size(88, 22);
             this.memoryViewButton.Text = "Show Memory";
             this.memoryViewButton.Click += new System.EventHandler(this.memoryViewButton_Click);
-            //
+            // 
             // followPCButton
-            //
+            // 
             this.followPCButton.Checked = true;
             this.followPCButton.CheckOnClick = true;
             this.followPCButton.CheckState = System.Windows.Forms.CheckState.Checked;
@@ -171,41 +182,55 @@ namespace Gear.GUI
             this.followPCButton.Image = ((System.Drawing.Image)(resources.GetObject("followPCButton.Image")));
             this.followPCButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.followPCButton.Name = "followPCButton";
-            this.followPCButton.Size = new System.Drawing.Size(57, 22);
+            this.followPCButton.Size = new System.Drawing.Size(64, 22);
             this.followPCButton.Text = "Follow PC";
             this.followPCButton.Click += new System.EventHandler(this.followPCButton_Click);
-            //
+            // 
             // programCounterLabel
-            //
+            // 
             this.programCounterLabel.Name = "programCounterLabel";
-            this.programCounterLabel.Size = new System.Drawing.Size(19, 22);
+            this.programCounterLabel.Size = new System.Drawing.Size(22, 22);
             this.programCounterLabel.Text = "---";
-            //
+            // 
             // zeroFlagLabel
-            //
+            // 
             this.zeroFlagLabel.Name = "zeroFlagLabel";
-            this.zeroFlagLabel.Size = new System.Drawing.Size(19, 22);
+            this.zeroFlagLabel.Size = new System.Drawing.Size(22, 22);
             this.zeroFlagLabel.Text = "---";
-            //
+            // 
             // carryFlagLabel
-            //
+            // 
             this.carryFlagLabel.Name = "carryFlagLabel";
-            this.carryFlagLabel.Size = new System.Drawing.Size(19, 22);
+            this.carryFlagLabel.Size = new System.Drawing.Size(22, 22);
             this.carryFlagLabel.Text = "---";
-            //
+            // 
             // processorStateLabel
-            //
+            // 
             this.processorStateLabel.Name = "processorStateLabel";
-            this.processorStateLabel.Size = new System.Drawing.Size(19, 22);
+            this.processorStateLabel.Size = new System.Drawing.Size(22, 22);
             this.processorStateLabel.Text = "---";
-            //
+            // 
             // toolStripSeparator5
-            //
+            // 
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
-            //
+            // 
+            // frameCountLabel
+            // 
+            this.frameCountLabel.AutoToolTip = true;
+            this.frameCountLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.frameCountLabel.Name = "frameCountLabel";
+            this.frameCountLabel.Size = new System.Drawing.Size(22, 22);
+            this.frameCountLabel.Text = "---";
+            this.frameCountLabel.ToolTipText = "Number of Video Frames";
+            // 
+            // toolStripSeparator7
+            // 
+            this.toolStripSeparator7.Name = "toolStripSeparator7";
+            this.toolStripSeparator7.Size = new System.Drawing.Size(6, 25);
+            // 
             // DisplayUnits
-            //
+            // 
             this.DisplayUnits.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.DisplayUnits.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.decimalUnits,
@@ -213,32 +238,32 @@ namespace Gear.GUI
             this.DisplayUnits.Image = ((System.Drawing.Image)(resources.GetObject("DisplayUnits.Image")));
             this.DisplayUnits.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.DisplayUnits.Name = "DisplayUnits";
-            this.DisplayUnits.Size = new System.Drawing.Size(44, 22);
+            this.DisplayUnits.Size = new System.Drawing.Size(47, 22);
             this.DisplayUnits.Text = "Units";
-            //
+            // 
             // decimalUnits
-            //
+            // 
             this.decimalUnits.Checked = true;
             this.decimalUnits.CheckState = System.Windows.Forms.CheckState.Checked;
             this.decimalUnits.Name = "decimalUnits";
-            this.decimalUnits.Size = new System.Drawing.Size(145, 22);
+            this.decimalUnits.Size = new System.Drawing.Size(143, 22);
             this.decimalUnits.Text = "Decimal";
             this.decimalUnits.Click += new System.EventHandler(this.decimalUnits_Click);
-            //
+            // 
             // hexadecimalUnits
-            //
+            // 
             this.hexadecimalUnits.Name = "hexadecimalUnits";
-            this.hexadecimalUnits.Size = new System.Drawing.Size(145, 22);
+            this.hexadecimalUnits.Size = new System.Drawing.Size(143, 22);
             this.hexadecimalUnits.Text = "Hexadecimal";
             this.hexadecimalUnits.Click += new System.EventHandler(this.hexadecimalUnits_Click);
-            //
+            // 
             // toolStripSeparator6
-            //
+            // 
             this.toolStripSeparator6.Name = "toolStripSeparator6";
             this.toolStripSeparator6.Size = new System.Drawing.Size(6, 25);
-            //
+            // 
             // OpcodeSize
-            //
+            // 
             this.OpcodeSize.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.OpcodeSize.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.longOpcodes,
@@ -246,27 +271,81 @@ namespace Gear.GUI
             this.OpcodeSize.Image = ((System.Drawing.Image)(resources.GetObject("OpcodeSize.Image")));
             this.OpcodeSize.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.OpcodeSize.Name = "OpcodeSize";
-            this.OpcodeSize.Size = new System.Drawing.Size(62, 22);
+            this.OpcodeSize.Size = new System.Drawing.Size(67, 22);
             this.OpcodeSize.Text = "Opcodes";
-            //
+            // 
             // longOpcodes
-            //
+            // 
             this.longOpcodes.Name = "longOpcodes";
-            this.longOpcodes.Size = new System.Drawing.Size(156, 22);
+            this.longOpcodes.Size = new System.Drawing.Size(152, 22);
             this.longOpcodes.Text = "Long Opcodes";
             this.longOpcodes.Click += new System.EventHandler(this.longOpcodes_Click);
-            //
+            // 
             // shortOpcodes
-            //
+            // 
             this.shortOpcodes.Checked = true;
             this.shortOpcodes.CheckState = System.Windows.Forms.CheckState.Checked;
             this.shortOpcodes.Name = "shortOpcodes";
-            this.shortOpcodes.Size = new System.Drawing.Size(156, 22);
+            this.shortOpcodes.Size = new System.Drawing.Size(152, 22);
             this.shortOpcodes.Text = "Short Opcodes";
             this.shortOpcodes.Click += new System.EventHandler(this.shortOpcodes_Click);
-            //
+            // 
+            // FrameBreakMode
+            // 
+            this.FrameBreakMode.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.FrameBreakMode.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.breakNone,
+            this.breakMiss,
+            this.breakAll});
+            this.FrameBreakMode.Image = ((System.Drawing.Image)(resources.GetObject("FrameBreakMode.Image")));
+            this.FrameBreakMode.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.FrameBreakMode.Name = "FrameBreakMode";
+            this.FrameBreakMode.Size = new System.Drawing.Size(82, 22);
+            this.FrameBreakMode.Text = "Video Break";
+            this.FrameBreakMode.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.FrameBreakMode.ToolTipText = "Enable break on end of video frame";
+            // 
+            // toolStripSeparator8
+            // 
+            this.toolStripSeparator8.Name = "toolStripSeparator8";
+            this.toolStripSeparator8.Size = new System.Drawing.Size(6, 25);
+            // 
+            // breakNone
+            // 
+            this.breakNone.AutoToolTip = true;
+            this.breakNone.CheckOnClick = true;
+            this.breakNone.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.breakNone.Name = "breakNone";
+            this.breakNone.Size = new System.Drawing.Size(180, 22);
+            this.breakNone.Text = "None";
+            this.breakNone.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.breakNone.Click += new System.EventHandler(this.VideoBreak_Click);
+            // 
+            // breakMiss
+            // 
+            this.breakMiss.CheckOnClick = true;
+            this.breakMiss.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.breakMiss.Name = "breakMiss";
+            this.breakMiss.Size = new System.Drawing.Size(180, 22);
+            this.breakMiss.Text = "Frame Miss";
+            this.breakMiss.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.breakMiss.ToolTipText = "Break if frame end misses WAIT_VID";
+            this.breakMiss.Click += new System.EventHandler(this.VideoBreak_Click);
+            // 
+            // breakAll
+            // 
+            this.breakAll.AutoToolTip = true;
+            this.breakAll.CheckOnClick = true;
+            this.breakAll.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.breakAll.Name = "breakAll";
+            this.breakAll.Size = new System.Drawing.Size(180, 22);
+            this.breakAll.Text = "Frame End";
+            this.breakAll.TextAlign = System.Drawing.ContentAlignment.TopLeft;
+            this.breakAll.ToolTipText = "Break on end of video frame";
+            this.breakAll.Click += new System.EventHandler(this.VideoBreak_Click);
+            // 
             // CogView
-            //
+            // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.assemblyPanel);
@@ -301,6 +380,12 @@ namespace Gear.GUI
         private System.Windows.Forms.ToolStripMenuItem longOpcodes;
         private System.Windows.Forms.ToolStripMenuItem shortOpcodes;
         private System.Windows.Forms.ToolTip toolTip1;
-
+        private System.Windows.Forms.ToolStripLabel frameCountLabel;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator7;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator8;
+        private System.Windows.Forms.ToolStripDropDownButton FrameBreakMode;
+        private System.Windows.Forms.ToolStripMenuItem breakNone;
+        private System.Windows.Forms.ToolStripMenuItem breakMiss;
+        private System.Windows.Forms.ToolStripMenuItem breakAll;
     }
 }

--- a/Gear/GUI/CogView.cs
+++ b/Gear/GUI/CogView.cs
@@ -50,6 +50,7 @@ namespace Gear.GUI
         private Brush StringBrush;
         private bool displayAsHexadecimal;
         private bool useShortOpcodes;
+        private FrameState breakVideo;
 
         public override string Title
         {
@@ -91,6 +92,11 @@ namespace Gear.GUI
             MonoFontBold = new Font(MonoFont, FontStyle.Bold);
 
             InitializeComponent();
+
+            breakNone.Checked = true;
+            breakMiss.Checked = false;
+            breakAll.Checked = false;
+            breakVideo = FrameState.frameMiss;
         }
 
         public Cog GetViewCog()
@@ -331,7 +337,9 @@ namespace Gear.GUI
             else if (Host is InterpretedCog) Repaint(force, (InterpretedCog)Host);
 
             programCounterLabel.Text = "PC: " + String.Format("{0:X8}", Host.ProgramCursor);
-            processorStateLabel.Text = "CPU State: " + Host.CogState;
+            processorStateLabel.Text = "CPU State: " + Host.CogState; // + Host.VideoStateString;
+            frameCountLabel.Text = "Frames: " + Host.VideoFramesString;
+            // frameCountLabel.Text = String.Format("Frames: {0}", Host.VideoFrames);
 
             assemblyPanel.CreateGraphics().DrawImageUnscaled(BackBuffer, 0, 0);
         }
@@ -452,6 +460,33 @@ namespace Gear.GUI
                 );
                 LastLine = line;
             }
+        }
+
+        public void VideoBreak_Click(object sender, EventArgs e)
+        {
+            if (sender == breakNone)
+            {
+                breakNone.Checked = true;
+                breakMiss.Checked = false;
+                breakAll.Checked = false;
+                breakVideo = FrameState.frameMiss;
+            }
+            if (sender == breakMiss)
+            {
+                breakNone.Checked = false;
+                breakMiss.Checked = true;
+                breakAll.Checked = false;
+                breakVideo = FrameState.frameMiss;
+            }
+            if (sender == breakAll)
+            {
+                breakNone.Checked = true;
+                breakMiss.Checked = false;
+                breakAll.Checked = false;
+                breakVideo = FrameState.frameNone;
+            }
+            Cog cog = Chip.GetCog(HostID);
+            cog.VideoBreak = breakVideo;
         }
 
     }

--- a/Gear/GUI/CogView.resx
+++ b/Gear/GUI/CogView.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -112,88 +112,103 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolStripSeparator4.GenerateMember" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="toolStripSeparator4.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="toolStripSeparator1.GenerateMember" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="toolStripSeparator1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="toolStripSeparator2.GenerateMember" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="toolStripSeparator2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="toolStripSeparator3.GenerateMember" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="toolStripSeparator3.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="toolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="memoryViewButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-      iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-      YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAgxJREFUOE+lkvtL
-      U2EYx+0PEbtpFwnBKPGKiJImGP0gYhIYs1E5GF5gIxkpA00JRSmMEF0ohMh+GaRWYlqabMVcNdS2QpaI
-      VqiDIYhk397vA6fXhCjyhYdzeM/5fp7vczkAdeL2cwho7v/wWzT1zcN+Pwhr51uY2/y41PQaF+wzKKiZ
-      QvaN58g0jyLd5KEUcQbg+84P/Cm2tncQjW3j68YWIqubCC3FcOJc478BAuGoZM6zvoRnakXEruEIjhc4
-      /g5gZop9c+voGAyLbQIfeBZxLL9BA1jzXvuGbWamuKh+GmmVbswE19A59FEBbmoAG7YbsLtm2mZmiml9
-      cvabNDwpz6YB7LYBoMXCumkJr7LOmnnHzBQ/9X2Bo2cOibm1GsBREbAQiYmw/8lnuCeWkVzcgnZlnw1j
-      3HV/wuNXK6i/9x5Hc6wawDlTXHbLJ+LZUBQPRyKwdQdxutwl1h+NLXHh5Ht1ewBHsiwawCW57HyDAfWR
-      dvl0uhZQ1eqX8aVc7EKLqrum651ATLf9OJx5XQM4KmY0xPzZ0hFAiQJnXB0WwME0E3IsL5B17ZlADqWb
-      NYDrOepdlcysmTWWOrxqbceRWtaLk0VO1XW72D5Vckd2gMBfq8zdpmUG62NJvKM4+XyziDk24xmfWoGE
-      s1c0gHPmbrPTpHNJKOCo2G1mZs20zcwUJ5yp1AB5+8/zEwgF5GMVDxh4AAAAAElFTkSuQmCC
-    </value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
   </data>
   <data name="followPCButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-      iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-      YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAgxJREFUOE+lkvtL
-      U2EYx+0PEbtpFwnBKPGKiJImGP0gYhIYs1E5GF5gIxkpA00JRSmMEF0ohMh+GaRWYlqabMVcNdS2QpaI
-      VqiDIYhk397vA6fXhCjyhYdzeM/5fp7vczkAdeL2cwho7v/wWzT1zcN+Pwhr51uY2/y41PQaF+wzKKiZ
-      QvaN58g0jyLd5KEUcQbg+84P/Cm2tncQjW3j68YWIqubCC3FcOJc478BAuGoZM6zvoRnakXEruEIjhc4
-      /g5gZop9c+voGAyLbQIfeBZxLL9BA1jzXvuGbWamuKh+GmmVbswE19A59FEBbmoAG7YbsLtm2mZmiml9
-      cvabNDwpz6YB7LYBoMXCumkJr7LOmnnHzBQ/9X2Bo2cOibm1GsBREbAQiYmw/8lnuCeWkVzcgnZlnw1j
-      3HV/wuNXK6i/9x5Hc6wawDlTXHbLJ+LZUBQPRyKwdQdxutwl1h+NLXHh5Ht1ewBHsiwawCW57HyDAfWR
-      dvl0uhZQ1eqX8aVc7EKLqrum651ATLf9OJx5XQM4KmY0xPzZ0hFAiQJnXB0WwME0E3IsL5B17ZlADqWb
-      NYDrOepdlcysmTWWOrxqbceRWtaLk0VO1XW72D5Vckd2gMBfq8zdpmUG62NJvKM4+XyziDk24xmfWoGE
-      s1c0gHPmbrPTpHNJKOCo2G1mZs20zcwUJ5yp1AB5+8/zEwgF5GMVDxh4AAAAAElFTkSuQmCC
-    </value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
   </data>
   <data name="DisplayUnits.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-      iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-      YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAgxJREFUOE+lkvtL
-      U2EYx+0PEbtpFwnBKPGKiJImGP0gYhIYs1E5GF5gIxkpA00JRSmMEF0ohMh+GaRWYlqabMVcNdS2QpaI
-      VqiDIYhk397vA6fXhCjyhYdzeM/5fp7vczkAdeL2cwho7v/wWzT1zcN+Pwhr51uY2/y41PQaF+wzKKiZ
-      QvaN58g0jyLd5KEUcQbg+84P/Cm2tncQjW3j68YWIqubCC3FcOJc478BAuGoZM6zvoRnakXEruEIjhc4
-      /g5gZop9c+voGAyLbQIfeBZxLL9BA1jzXvuGbWamuKh+GmmVbswE19A59FEBbmoAG7YbsLtm2mZmiml9
-      cvabNDwpz6YB7LYBoMXCumkJr7LOmnnHzBQ/9X2Bo2cOibm1GsBREbAQiYmw/8lnuCeWkVzcgnZlnw1j
-      3HV/wuNXK6i/9x5Hc6wawDlTXHbLJ+LZUBQPRyKwdQdxutwl1h+NLXHh5Ht1ewBHsiwawCW57HyDAfWR
-      dvl0uhZQ1eqX8aVc7EKLqrum651ATLf9OJx5XQM4KmY0xPzZ0hFAiQJnXB0WwME0E3IsL5B17ZlADqWb
-      NYDrOepdlcysmTWWOrxqbceRWtaLk0VO1XW72D5Vckd2gMBfq8zdpmUG62NJvKM4+XyziDk24xmfWoGE
-      s1c0gHPmbrPTpHNJKOCo2G1mZs20zcwUJ5yp1AB5+8/zEwgF5GMVDxh4AAAAAElFTkSuQmCC
-    </value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
   </data>
   <data name="OpcodeSize.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-      iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-      YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAgxJREFUOE+lkvtL
-      U2EYx+0PEbtpFwnBKPGKiJImGP0gYhIYs1E5GF5gIxkpA00JRSmMEF0ohMh+GaRWYlqabMVcNdS2QpaI
-      VqiDIYhk397vA6fXhCjyhYdzeM/5fp7vczkAdeL2cwho7v/wWzT1zcN+Pwhr51uY2/y41PQaF+wzKKiZ
-      QvaN58g0jyLd5KEUcQbg+84P/Cm2tncQjW3j68YWIqubCC3FcOJc478BAuGoZM6zvoRnakXEruEIjhc4
-      /g5gZop9c+voGAyLbQIfeBZxLL9BA1jzXvuGbWamuKh+GmmVbswE19A59FEBbmoAG7YbsLtm2mZmiml9
-      cvabNDwpz6YB7LYBoMXCumkJr7LOmnnHzBQ/9X2Bo2cOibm1GsBREbAQiYmw/8lnuCeWkVzcgnZlnw1j
-      3HV/wuNXK6i/9x5Hc6wawDlTXHbLJ+LZUBQPRyKwdQdxutwl1h+NLXHh5Ht1ewBHsiwawCW57HyDAfWR
-      dvl0uhZQ1eqX8aVc7EKLqrum651ATLf9OJx5XQM4KmY0xPzZ0hFAiQJnXB0WwME0E3IsL5B17ZlADqWb
-      NYDrOepdlcysmTWWOrxqbceRWtaLk0VO1XW72D5Vckd2gMBfq8zdpmUG62NJvKM4+XyziDk24xmfWoGE
-      s1c0gHPmbrPTpHNJKOCo2G1mZs20zcwUJ5yp1AB5+8/zEwgF5GMVDxh4AAAAAElFTkSuQmCC
-    </value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <data name="FrameBreakMode.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>110, 17</value>
   </metadata>
 </root>

--- a/Gear/GUI/Emulator.Designer.cs
+++ b/Gear/GUI/Emulator.Designer.cs
@@ -49,7 +49,6 @@ namespace Gear.GUI
         private void InitializeComponent()
         {
             System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-            System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Emulator));
             this.controlBar = new System.Windows.Forms.ToolStrip();
             this.openBinaryButton = new System.Windows.Forms.ToolStripButton();
@@ -72,7 +71,6 @@ namespace Gear.GUI
             this.hubViewSplitter = new Gear.GUI.CollapsibleSplitter();
             this.hubView = new Gear.GUI.HubView();
             toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.controlBar.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -80,11 +78,6 @@ namespace Gear.GUI
             // 
             toolStripSeparator1.Name = "toolStripSeparator1";
             toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
-            // 
-            // toolStripSeparator2
-            // 
-            toolStripSeparator2.Name = "toolStripSeparator2";
-            toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
             // 
             // controlBar
             // 
@@ -97,7 +90,6 @@ namespace Gear.GUI
             this.stopEmulatorButton,
             this.stepInstructionButton,
             this.stepClockButton,
-            toolStripSeparator2,
             this.unpinButton,
             this.pinButton,
             this.floatButton,
@@ -237,7 +229,7 @@ namespace Gear.GUI
             this.AboutPluginButton.Image = ((System.Drawing.Image)(resources.GetObject("AboutPluginButton.Image")));
             this.AboutPluginButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.AboutPluginButton.Name = "AboutPluginButton";
-            this.AboutPluginButton.Size = new System.Drawing.Size(44, 22);
+            this.AboutPluginButton.Size = new System.Drawing.Size(44, 19);
             this.AboutPluginButton.Text = "About";
             this.AboutPluginButton.ToolTipText = "About Plugin";
             this.AboutPluginButton.Visible = false;
@@ -275,7 +267,7 @@ namespace Gear.GUI
             this.documentsTab.Name = "documentsTab";
             this.documentsTab.SelectedIndex = 0;
             this.documentsTab.ShowToolTips = true;
-            this.documentsTab.Size = new System.Drawing.Size(657, 403);
+            this.documentsTab.Size = new System.Drawing.Size(657, 408);
             this.documentsTab.TabIndex = 5;
             this.documentsTab.Click += new System.EventHandler(this.documentsTab_Click);
             this.documentsTab.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.documentsTab_KeyPress);
@@ -289,7 +281,7 @@ namespace Gear.GUI
             this.pinnedSplitter.Cursor = System.Windows.Forms.Cursors.HSplit;
             this.pinnedSplitter.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.pinnedSplitter.ExpandParentForm = false;
-            this.pinnedSplitter.Location = new System.Drawing.Point(215, 428);
+            this.pinnedSplitter.Location = new System.Drawing.Point(215, 433);
             this.pinnedSplitter.Name = "collapsibleSplitter1";
             this.pinnedSplitter.TabIndex = 4;
             this.pinnedSplitter.TabStop = false;

--- a/Gear/GUI/Emulator.cs
+++ b/Gear/GUI/Emulator.cs
@@ -46,7 +46,7 @@ namespace Gear.GUI
         private List<Control> FloatControls;//!< @brief List of floating controls.
 
         /// @brief Stopwatch to periodically rerun a step of the emulation
-        private Timer runTimer;             
+        private Timer runTimer;
 
         /// @brief Default Constructor.
         /// @param[in] source Binary program loaded (path & name)
@@ -242,16 +242,16 @@ namespace Gear.GUI
                 //Dynamic load and compile the plugin module as a class, giving the chip 
                 // instance as a parameter.
                 PluginBase plugin = ModuleCompiler.LoadModule(
-                    code, 
-                    instanceName, 
-                    references.ToArray(), 
+                    code,
+                    instanceName,
+                    references.ToArray(),
                     Chip
                 );
 
                 if (plugin == null)     //if it fails...
                 {
                     // ...open plugin editor in other window
-                    PluginEditor pe = new PluginEditor(false);   
+                    PluginEditor pe = new PluginEditor(false);
                     pe.OpenFile(FileName, true);
                     pe.MdiParent = this.MdiParent;
                     pe.Show();
@@ -263,7 +263,7 @@ namespace Gear.GUI
                 else               //if success compiling & instantiate the new class...
                 {
                     //...add the reference to the plugin list of the emulator instance
-                    AttachPlugin(plugin);   
+                    AttachPlugin(plugin);
                     Properties.Settings.Default.LastPlugin = FileName;  //update location of last plugin
                     Properties.Settings.Default.Save();
                 }
@@ -296,7 +296,7 @@ namespace Gear.GUI
         private void openBinary_Click(object sender, EventArgs e)
         {
             OpenFileDialog openFileDialog = new OpenFileDialog();
-            openFileDialog.Filter = "Propeller Runtime Image (*.binary;*.eeprom)|*.binary;" + 
+            openFileDialog.Filter = "Propeller Runtime Image (*.binary;*.eeprom)|*.binary;" +
                 "*.eeprom|All Files (*.*)|*.*";
             openFileDialog.Title = "Open Propeller Binary...";
             openFileDialog.FileName = Source;
@@ -338,8 +338,8 @@ namespace Gear.GUI
             if (c != null)
                 ((PluginBase)c).Repaint(true);
 
-            if ( (documentsTab.SelectedTab != null) && 
-                 ((c = documentsTab.SelectedTab.GetNextControl(null, true)) != null) )
+            if ((documentsTab.SelectedTab != null) &&
+                 ((c = documentsTab.SelectedTab.GetNextControl(null, true)) != null))
                 ((PluginBase)c).Repaint(true);
 
             hubView.DataChanged();
@@ -372,7 +372,7 @@ namespace Gear.GUI
         {
             TabPage tp = documentsTab.SelectedTab;
             PluginBase p = (PluginBase)tp.Controls[0];
-            
+
             if (p != null)          //test if cast to PluginBase works...
             {
                 if (p.IsClosable)   //... so, test if we can close the tab 
@@ -384,7 +384,7 @@ namespace Gear.GUI
                         //tab changing housekeeping for plugin close button
                         documentsTab_Click(this, e);
                         //detach the plugin from the emulator
-                        this.DetachPlugin(p);           
+                        this.DetachPlugin(p);
                         p.Dispose();
                     }
                     tp.Parent = null;   //delete the reference to plugin
@@ -544,11 +544,13 @@ namespace Gear.GUI
                     closeButton.Enabled = true;
                 else
                     closeButton.Enabled = false;
+                b.Repaint(false);
             }
             else
             {
                 closeButton.Enabled = false;
             }
+            tp.Invalidate();
         }
 
         /// @todo Document Gear.GUI.Emulator.documentsTab_KeyPress()
@@ -574,7 +576,6 @@ namespace Gear.GUI
                     runTimer.Start();
             }
         }
-
     }
 }
 

--- a/Gear/GUI/Emulator.resx
+++ b/Gear/GUI/Emulator.resx
@@ -120,9 +120,6 @@
   <metadata name="toolStripSeparator1.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="toolStripSeparator2.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>False</value>
-  </metadata>
   <metadata name="controlBar.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/Gear/Properties/AssemblyInfo.cs
+++ b/Gear/Properties/AssemblyInfo.cs
@@ -66,5 +66,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("15.03.26.0")]
-[assembly: AssemblyFileVersion("15.03.26.0")]
+[assembly: AssemblyVersion("15.03.27.0")]
+[assembly: AssemblyFileVersion("15.03.27.0")]

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ Read more in forum threads:
 * [More GEAR - Improved Emulation of the Propeller](http://forums.parallax.com/showthread.php/100380-More-GEAR-Improved-Emulation-of-the-Propeller)
 * [GEAR: Propeller Debugging Environment](http://forums.parallax.com/showthread.php/91084-GEAR-Propeller-Debugging-Environment)
 
+## V15.03.27
+
+* Corrected timing of Video Generator Frame Reload.
+* Added the ability to set breaks on video frame reloads, either all or just those that do not coinside with a WAIT_VID.
+* Fixed refresh when switching between tabs.
+
 ## V15.03.26
 
 * Corrections on all the effects for PASM hub operations (zero, carry and return): CLKSET. COGID, COGINIT, COGSTOP, LOCKNEW, LOCKRET, LOCKSET, LOCKCLR. There was some missing values for carry & zero flags.


### PR DESCRIPTION
Gear did not appear to be correctly emulating the behavior of the Propeller if the end of a video frame did not coincide with a WAITVID instruction. The Gear Video Generator was just waiting with FrameClocks = 0 until the occurrence of a WAITVID command. However, from the Propeller documentation, at the end of a video frame the colours and pixels should be loaded from the source and destination of whatever instruction is currently executing, and the frame and pixel clocks reset. The code has been revised to emulate this for a Native Cog. For an emulated cog, if not in a WAITVID the colour and pixel values loaded are unknown, so zeros are loaded by default.

It was difficult to detect video frame timing issues, so I have added a UI to enable breaks on either all video frame reloads or only those that miss a WAITVID.

Finally, the cog pages were not being refreshed when switching between tabs, it was necessary to click on the scroll bar to force a refresh. This has been fixed.