### PR TITLE
Added carry and zero flag changes to waitvid instruction

### DIFF
--- a/Gear/EmulationCore/NativeCog.cs
+++ b/Gear/EmulationCore/NativeCog.cs
@@ -584,6 +584,7 @@ namespace Gear.EmulationCore
                     StateCount = 4;
                     break;
                 case Assembly.InstructionCodes.WAITVID:
+                    InstructionWAITVID();
                     NextState = CogRunState.WAIT_VID;
                     State = CogRunState.WAIT_PREWAIT;
                     StateCount = 4;
@@ -1263,6 +1264,14 @@ namespace Gear.EmulationCore
                 PC = SourceValue & 0x1FF;
 
             return ZeroResult;
+        }
+
+        private void InstructionWAITVID()
+        {
+            ulong result = (ulong)SourceValue + (ulong)DestinationValue;
+            DataResult = (uint)result;
+            ZeroResult = DataResult == 0;
+            CarryResult = (result & 0x100000000) != 0;
         }
     }
 }


### PR DESCRIPTION
Hey, 
I am recently working on an video generator simulation program for an propeller simulator on my own ( bachelor thesis, continuing the work of mbaeten who also contributed to this repo) and because I took a look at the verilog data  published by parallax, I can tell that the carry and zero flag of an waitvid instruction are set like the opcode of the waitvid command tells ( even if the declaration differes, depending on where you search for an answer in the manual),
thus a simple add is performed and zero = src+dst == 0 and carry = <src + dst == overflow>.
Because I used your code for understanding the procedure and ported some of your code (composite logic of video generator) 
I wanted to give you some of my insights as well :)

Besides this, I also recognized that your video generator updates values immediately (see issue), but it usually (accoring to verilog) takes 1 plla cycle to load the new values (especially vcfg and vscl, in case of pixels (and colors I think) you always update after the old value gets shifted out...) to be recognized by the video generator, have you tested the video generator simulation against a real video generator in this manner ?


Thanks for your time, if I had a wrong clue about anything, please answer :)