### PR TITLE
Changed VideoGenerator Video Generation Procedure to fit Verilog Code

### DIFF
--- a/Gear/EmulationCore/NativeCog.cs
+++ b/Gear/EmulationCore/NativeCog.cs
@@ -602,7 +602,7 @@ namespace Gear.EmulationCore
             colours = DestinationValue;
             pixels = SourceValue;
             if (State == CogRunState.WAIT_VID)
-            { 
+            {
                 State = CogRunState.WAIT_CYCLES;
                 StateCount = 3; // Minimum of 7 clocks in total
                 frameFlag = FrameState.frameHit;

--- a/Gear/EmulationCore/NativeCog.cs
+++ b/Gear/EmulationCore/NativeCog.cs
@@ -602,7 +602,7 @@ namespace Gear.EmulationCore
             colours = DestinationValue;
             pixels = SourceValue;
             if (State == CogRunState.WAIT_VID)
-            {
+            { 
                 State = CogRunState.WAIT_CYCLES;
                 StateCount = 3; // Minimum of 7 clocks in total
                 frameFlag = FrameState.frameHit;

--- a/Gear/EmulationCore/VideoGenerator.cs
+++ b/Gear/EmulationCore/VideoGenerator.cs
@@ -200,7 +200,7 @@ namespace Gear.EmulationCore
             }
 
             FrameClocks = Scale & 0xFFF;    // Copy our frameclocks out of the scale register
-            PixelClocks = PixelClockStart;                // Always serialize out the first pixel on first clock
+            PixelClocks = PixelClockStart;  // update PixelClock, similar to verilog
         }
 
         private void FillComposite(uint color)
@@ -314,9 +314,10 @@ namespace Gear.EmulationCore
                     break;
             }
 
+            // Composite Processes gets updated one tick later than VGA
             ShiftOut = Discrete;
 
-            // Find the pixel color we need to shift out
+            // Find the pixel color which will be processed by VGA Directly
             switch (ColorMode)
             {
                 // Four color video


### PR DESCRIPTION
I gave it a try, did not test it completley, but called in this order it worked for the examples I used in VGA and TV Mode like before, also Video Generator processes data in same order as verilog code.
![bachelor_thesis_09](https://user-images.githubusercontent.com/80335749/158907976-3e9d6b29-c52c-4973-a2b7-a85998b2f9cb.png)

![bachelor_thesis_08](https://user-images.githubusercontent.com/80335749/158908090-7ba6155f-c0a9-494f-a5c6-f5aeab5239a9.png)

